### PR TITLE
usePromiseWithInterval: add manual retry option

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,12 +157,18 @@ export const UserEchoWithIntervalComponent = () => {
 ```
 
 Besides that, you can also perform calls manually, and check the current amount of times your request was performed.
-`load` function is a promise loader function from the `usePromise` hook.
 
 ```tsx
 export const IntervalAndManualCheckComponent = () => {
     const echoWithArguments = (param: string) => echo(param);
-    const [result, start, stop, load,, retries] = usePromiseWithInterval<string, [string]>(echoWithArguments, 2000);
+    const [
+        result, // good old PromiseResultShape
+        start,
+        stop,
+        load, // manual load trigger
+        reset, // promise shape reset function
+        tryCount // amount of times your request was performed
+    ] = usePromiseWithInterval<string, [string]>(echoWithArguments, 2000);
 
     const startCallingEcho = React.useCallback(() => {
         start("It's me again!!!");

--- a/README.md
+++ b/README.md
@@ -156,6 +156,33 @@ export const UserEchoWithIntervalComponent = () => {
 };
 ```
 
+Besides that, you can also perform calls manually, and check the current amount of times your request was performed.
+`load` function is a promise loader function from the `usePromise` hook.
+
+```tsx
+export const IntervalAndManualCheckComponent = () => {
+    const echoWithArguments = (param: string) => echo(param);
+    const [result, start, stop, load,, retries] = usePromiseWithInterval<string, [string]>(echoWithArguments, 2000);
+
+    const startCallingEcho = React.useCallback(() => {
+        start("It's me again!!!");
+    }, [start]);
+
+    return (
+        <>
+            {result.match({
+                Idle: () => <></>,
+                Loading: () => <span>I say "{text}"!</span>,
+                Rejected: (err) => <span>Oops, something went wrong! Error: {err}</span>,
+                Resolved: (echoResponse) => <span>Echo says "{echoResponse}"</span>,
+            })}
+        </>
+        <button onClick={stop}>Stop</button>
+        <button disabled={retries < 3} onClick={load}>Retry manually</button>
+    );
+};
+```
+
 ### Callback functions
 
 Apart from rendering phase, you may want to perform some side effect functions when your promise is in a specific state. I.e. you may want to invoke another asynchronous function when the data is resolved or when the error is being thrown.

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,5 +32,7 @@ export type UsePromiseWithInterval<T, E, A extends any[]> = [
     result: PromiseResultShape<T, E>,
     start: (...args: A) => void,
     stop: () => void,
+    load: PromiseLoader<void, A>,
     reset: () => void,
+    retries: number,
 ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,5 +34,5 @@ export type UsePromiseWithInterval<T, E, A extends any[]> = [
     stop: () => void,
     load: PromiseLoader<void, A>,
     reset: () => void,
-    retries: number,
+    tryCount: number,
 ];

--- a/src/usePromiseWithInterval.test.tsx
+++ b/src/usePromiseWithInterval.test.tsx
@@ -34,7 +34,7 @@ const nextExpectedResult = async (result: string, unexpectedResult?: string) => 
 };
 
 const TestComponent: React.FC<TestComponentWithoutArguments> = ({ loader, interval }) => {
-    const [result, start, stop, load, , retries] = usePromiseWithInterval(loader, interval);
+    const [result, start, stop, load, , tryCount] = usePromiseWithInterval(loader, interval);
 
     return (
         <>
@@ -53,7 +53,7 @@ const TestComponent: React.FC<TestComponentWithoutArguments> = ({ loader, interv
             <button data-testid={retryButtonId} onClick={load}>
                 Retry
             </button>
-            <p data-testid={retriesParagraphId}>{retries}</p>
+            <p data-testid={retriesParagraphId}>{tryCount}</p>
         </>
     );
 };

--- a/src/usePromiseWithInterval.test.tsx
+++ b/src/usePromiseWithInterval.test.tsx
@@ -19,6 +19,8 @@ const SAMPLE_TEXT = "Some asynchronously loaded text";
 
 const startButtonId = "startButton";
 const stopButtonId = "stopButton";
+const retriesParagraphId = "retries";
+const retryButtonId = "retry";
 
 const nextExpectedResult = async (result: string, unexpectedResult?: string) => {
     act(() => {
@@ -32,7 +34,7 @@ const nextExpectedResult = async (result: string, unexpectedResult?: string) => 
 };
 
 const TestComponent: React.FC<TestComponentWithoutArguments> = ({ loader, interval }) => {
-    const [result, start, stop] = usePromiseWithInterval(loader, interval);
+    const [result, start, stop, load, , retries] = usePromiseWithInterval(loader, interval);
 
     return (
         <>
@@ -48,6 +50,10 @@ const TestComponent: React.FC<TestComponentWithoutArguments> = ({ loader, interv
             <button data-testid={stopButtonId} onClick={stop}>
                 Clear
             </button>
+            <button data-testid={retryButtonId} onClick={load}>
+                Retry
+            </button>
+            <p data-testid={retriesParagraphId}>{retries}</p>
         </>
     );
 };
@@ -78,6 +84,7 @@ describe("usePromiseWithInterval with a no-arguments loader function", () => {
 
         const startButton = screen.getByTestId(startButtonId);
         const stopButton = screen.getByTestId(stopButtonId);
+        const retryButton = screen.getByTestId(retryButtonId);
 
         fireEvent.click(startButton);
 
@@ -88,5 +95,13 @@ describe("usePromiseWithInterval with a no-arguments loader function", () => {
 
         fireEvent.click(stopButton);
         await nextExpectedResult(`${SAMPLE_TEXT} 3`);
+        let retriesParagraph = await screen.findByTestId(retriesParagraphId);
+
+        expect(retriesParagraph.textContent).toBe("4");
+
+        fireEvent.click(retryButton);
+
+        retriesParagraph = await screen.findByTestId(retriesParagraphId);
+        expect(retriesParagraph.textContent).toBe("5");
     });
 });

--- a/src/usePromiseWithInterval.ts
+++ b/src/usePromiseWithInterval.ts
@@ -7,11 +7,11 @@ export const usePromiseWithInterval = <T, Args extends any[], E = string>(
     interval: number,
 ): UsePromiseWithInterval<T, E, Args> => {
     const [result, load, reset] = usePromise<T, Args, E>(loaderFn);
-    const [retries, setRetries] = useState<number>(0);
+    const [tryCount, setTryCount] = useState<number>(0);
 
     const increment = useCallback(() => {
-        setRetries((v) => v + 1);
-    }, [setRetries]);
+        setTryCount((v) => v + 1);
+    }, [setTryCount]);
 
     const timer: MutableRefObject<ReturnType<typeof setTimeout> | undefined> = useRef(undefined);
 
@@ -42,5 +42,5 @@ export const usePromiseWithInterval = <T, Args extends any[], E = string>(
         };
     }, [timer]);
 
-    return [result, start, stop, load, reset, retries];
+    return [result, start, stop, load, reset, tryCount];
 };


### PR DESCRIPTION
As in the README:

You can also perform calls manually, and check the current amount of times your request was performed.
`load` function is a promise loader function from the `usePromise` hook.

```tsx
export const IntervalAndManualCheckComponent = () => {
    const echoWithArguments = (param: string) => echo(param);
    const [result, start, stop, load,, retries] = usePromiseWithInterval<string, [string]>(echoWithArguments, 2000);
    const startCallingEcho = React.useCallback(() => {
        start("It's me again!!!");
    }, [start]);
    return (
        <>
            {result.match({
                Idle: () => <></>,
                Loading: () => <span>I say "{text}"!</span>,
                Rejected: (err) => <span>Oops, something went wrong! Error: {err}</span>,
                Resolved: (echoResponse) => <span>Echo says "{echoResponse}"</span>,
            })}
        </>
        <button onClick={stop}>Stop</button>
        <button disabled={retries < 3} onClick={load}>Retry manually</button>
    );
};
```