### PR TITLE
Fix reset interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ export const IntervalAndManualCheckComponent = () => {
         stop,
         load, // manual load trigger
         reset, // promise shape reset function
-        tryCount // amount of times your request was performed
+        tryCount // amount of times your request was performed,
+        resetTryCount // reset amount of times your request was performed
     ] = usePromiseWithInterval<string, [string]>(echoWithArguments, 2000);
 
     const startCallingEcho = React.useCallback(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,4 +35,5 @@ export type UsePromiseWithInterval<T, E, A extends any[]> = [
     load: PromiseLoader<void, A>,
     reset: () => void,
     tryCount: number,
+    resetTryCount: () => void,
 ];

--- a/src/usePromiseWithInterval.ts
+++ b/src/usePromiseWithInterval.ts
@@ -6,7 +6,7 @@ export const usePromiseWithInterval = <T, Args extends any[], E = string>(
     loaderFn: PromiseLoader<T, Args>,
     interval: number,
 ): UsePromiseWithInterval<T, E, Args> => {
-    const [result, load, reset] = usePromise<T, Args, E>(loaderFn);
+    const [result, load, resetPromise] = usePromise<T, Args, E>(loaderFn);
     const [tryCount, setTryCount] = useState<number>(0);
 
     const increment = useCallback(() => {
@@ -24,6 +24,12 @@ export const usePromiseWithInterval = <T, Args extends any[], E = string>(
         },
         [load, interval, timer],
     );
+
+    const reset = useCallback(() => {
+        reset();
+        clearInterval(timer.current as NodeJS.Timer);
+        setTryCount(0);
+    }, [resetPromise, timer, setTryCount]);
 
     useEffect(() => {
         if (result.isLoading) {


### PR DESCRIPTION
- update `tryCount` in the timeout function, instead in the `useEffect` hook.
- return additional `resetTryCount` function for reseting the counter

- WIP: one test issue - in `usePromiseWithInterval.test.tsx`, when retrying the polling, I can't get the promise resolved - it stays in the Idle state. 